### PR TITLE
feat: add accountUids config to dataProcessor

### DIFF
--- a/Classes/DataProcessing/TweetProcessor.php
+++ b/Classes/DataProcessing/TweetProcessor.php
@@ -29,12 +29,11 @@ class TweetProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ): array {
-        $accounts = $cObj->getRecords('tx_ximatwitterclient_domain_model_account', [
-            'uidInList.' => [
-                'field' => 'twitter',
-            ],
-            'pidInList' => 0,
-        ]);
+        $queryConfiguration = ['uidInList.' => ['field' => 'twitter'], 'pidInList' => 0];
+        if (isset($processorConfiguration['accountUids'])) {
+            $queryConfiguration = ['uidInList' => $processorConfiguration['accountUids'], 'pidInList' => 0];
+        }
+        $accounts = $cObj->getRecords('tx_ximatwitterclient_domain_model_account', $queryConfiguration);
 
         $accountUids = array_map(function ($account) {
             return $account['uid'];


### PR DESCRIPTION
This PR makes the DataProcessor work outside of content element context. Tweets can be fetched using a simple `FLUIDTEMPLATE`:

```
lib.twitter = FLUIDTEMPLATE
lib.twitter {
  dataProcessing.1736344977 = Xima\XimaTwitterClient\DataProcessing\TweetProcessor
  dataProcessing.1736344977.maxItems = 10
  dataProcessing.1736344977.accountUids = 1,3,5
}
```