### PR TITLE
Cleanup tweets

### DIFF
--- a/Classes/Command/CleanupTweetsCommand.php
+++ b/Classes/Command/CleanupTweetsCommand.php
@@ -12,16 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTwitterClient\Domain\Repository\TweetRepository;
 
 class CleanupTweetsCommand extends Command
 {
     private const DEFAULT_LIFETIME_DAYS = 180;
-
-    private const TABLE_TWEET = 'tx_ximatwitterclient_domain_model_tweet';
-
-    private const TABLE_FILE_REFERENCE = 'sys_file_reference';
 
     public function __construct(
         private readonly LoggerInterface $logger,
@@ -106,14 +104,14 @@ class CleanupTweetsCommand extends Command
      */
     private function deleteFilesAndReferences(array $tweetUids): int
     {
-        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_FILE_REFERENCE);
+        $qb = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
         $qb->getRestrictions()->removeAll();
 
         $fileReferences = $qb->select('uid', 'uid_local')
-            ->from(self::TABLE_FILE_REFERENCE)
+            ->from('sys_file_reference')
             ->where(
                 $qb->expr()->in('uid_foreign', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
-                $qb->expr()->eq('tablenames', $qb->createNamedParameter(self::TABLE_TWEET)),
+                $qb->expr()->eq('tablenames', $qb->createNamedParameter('tx_ximatwitterclient_domain_model_tweet')),
             )
             ->executeQuery()
             ->fetchAllAssociative();
@@ -142,13 +140,14 @@ class CleanupTweetsCommand extends Command
      */
     private function deleteTweets(array $tweetUids): int
     {
-        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_TWEET);
-        $qb->getRestrictions()->removeAll();
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $cmd = [];
+        foreach ($tweetUids as $uid) {
+            $cmd['tx_ximatwitterclient_domain_model_tweet'][$uid]['delete'] = 1;
+        }
+        $dataHandler->start([], $cmd);
+        $dataHandler->process_cmdmap();
 
-        return (int)$qb->delete(self::TABLE_TWEET)
-            ->where(
-                $qb->expr()->in('uid', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
-            )
-            ->executeStatement();
+        return count($tweetUids);
     }
 }

--- a/Classes/Command/CleanupTweetsCommand.php
+++ b/Classes/Command/CleanupTweetsCommand.php
@@ -118,10 +118,13 @@ class CleanupTweetsCommand extends Command
             ->executeQuery()
             ->fetchAllAssociative();
 
+        $deletedFiles = 0;
+
         foreach ($fileReferences as $fileReference) {
             try {
                 $file = $this->resourceFactory->getFileObject((int)$fileReference['uid_local']);
                 $file->delete();
+                $deletedFiles++;
             } catch (\Exception $e) {
                 $this->logger->warning('Could not delete file', [
                     'fileReferenceUid' => $fileReference['uid'],
@@ -131,15 +134,7 @@ class CleanupTweetsCommand extends Command
             }
         }
 
-        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_FILE_REFERENCE);
-        $qb->getRestrictions()->removeAll();
-
-        return (int)$qb->delete(self::TABLE_FILE_REFERENCE)
-            ->where(
-                $qb->expr()->in('uid_foreign', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
-                $qb->expr()->eq('tablenames', $qb->createNamedParameter(self::TABLE_TWEET)),
-            )
-            ->executeStatement();
+        return $deletedFiles;
     }
 
     /**

--- a/Classes/Command/CleanupTweetsCommand.php
+++ b/Classes/Command/CleanupTweetsCommand.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xima\XimaTwitterClient\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use Xima\XimaTwitterClient\Domain\Repository\TweetRepository;
+
+class CleanupTweetsCommand extends Command
+{
+    private const DEFAULT_LIFETIME_DAYS = 180;
+
+    private const TABLE_TWEET = 'tx_ximatwitterclient_domain_model_tweet';
+
+    private const TABLE_FILE_REFERENCE = 'sys_file_reference';
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly TweetRepository $tweetRepository,
+        private readonly ConnectionPool $connectionPool,
+        private readonly ResourceFactory $resourceFactory,
+        ?string $name = null,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Remove tweets (and their images) older than a given lifetime')
+            ->addOption(
+                'lifetime',
+                'l',
+                InputOption::VALUE_OPTIONAL,
+                'Maximum age of tweets in days (default: 180)',
+                (string)self::DEFAULT_LIFETIME_DAYS,
+            )
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Show what would be deleted without actually deleting',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        Bootstrap::initializeBackendAuthentication();
+
+        $io = new SymfonyStyle($input, $output);
+        $isDryRun = (bool)$input->getOption('dry-run');
+        $lifetimeDays = (int)$input->getOption('lifetime');
+
+        if ($lifetimeDays <= 0) {
+            $io->error('Lifetime must be a positive number of days.');
+            return Command::FAILURE;
+        }
+
+        $io->title('Twitter Cleanup');
+
+        $threshold = new \DateTimeImmutable(sprintf('-%d days', $lifetimeDays));
+        $io->text(sprintf('Removing tweets older than %s (%d days)...', $threshold->format('Y-m-d H:i:s'), $lifetimeDays));
+
+        $oldTweets = $this->tweetRepository->findOlderThan($threshold);
+        $tweetCount = count($oldTweets);
+
+        if ($tweetCount === 0) {
+            $io->info('No tweets found to clean up.');
+            return Command::SUCCESS;
+        }
+
+        $io->text(sprintf('Found %d tweet(s) to remove.', $tweetCount));
+
+        if ($isDryRun) {
+            $io->warning('Dry run: No tweets were deleted.');
+            return Command::SUCCESS;
+        }
+
+        $tweetUids = array_map(static fn (array $row): int => (int)$row['uid'], $oldTweets);
+        $deletedFiles = $this->deleteFilesAndReferences($tweetUids);
+        $deletedTweets = $this->deleteTweets($tweetUids);
+
+        $io->newLine();
+        $io->success(sprintf('Deleted %d tweet(s) and %d file reference(s).', $deletedTweets, $deletedFiles));
+
+        $this->logger->info('Cleaned up old tweets', [
+            'deletedTweets' => $deletedTweets,
+            'deletedFiles' => $deletedFiles,
+            'thresholdDate' => $threshold->format('Y-m-d H:i:s'),
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param int[] $tweetUids
+     */
+    private function deleteFilesAndReferences(array $tweetUids): int
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_FILE_REFERENCE);
+        $qb->getRestrictions()->removeAll();
+
+        $fileReferences = $qb->select('uid', 'uid_local')
+            ->from(self::TABLE_FILE_REFERENCE)
+            ->where(
+                $qb->expr()->in('uid_foreign', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
+                $qb->expr()->eq('tablenames', $qb->createNamedParameter(self::TABLE_TWEET)),
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($fileReferences as $fileReference) {
+            try {
+                $file = $this->resourceFactory->getFileObject((int)$fileReference['uid_local']);
+                $file->delete();
+            } catch (\Exception $e) {
+                $this->logger->warning('Could not delete file', [
+                    'fileReferenceUid' => $fileReference['uid'],
+                    'fileUid' => $fileReference['uid_local'],
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_FILE_REFERENCE);
+        $qb->getRestrictions()->removeAll();
+
+        return (int)$qb->delete(self::TABLE_FILE_REFERENCE)
+            ->where(
+                $qb->expr()->in('uid_foreign', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
+                $qb->expr()->eq('tablenames', $qb->createNamedParameter(self::TABLE_TWEET)),
+            )
+            ->executeStatement();
+    }
+
+    /**
+     * @param int[] $tweetUids
+     */
+    private function deleteTweets(array $tweetUids): int
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE_TWEET);
+        $qb->getRestrictions()->removeAll();
+
+        return (int)$qb->delete(self::TABLE_TWEET)
+            ->where(
+                $qb->expr()->in('uid', $qb->quoteArrayBasedValueListToIntegerList($tweetUids)),
+            )
+            ->executeStatement();
+    }
+}

--- a/Classes/Domain/Repository/TweetRepository.php
+++ b/Classes/Domain/Repository/TweetRepository.php
@@ -2,6 +2,7 @@
 
 namespace Xima\XimaTwitterClient\Domain\Repository;
 
+use Doctrine\DBAL\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -26,6 +27,22 @@ class TweetRepository extends Repository
             ->from('tx_ximatwitterclient_domain_model_tweet')
             ->where(
                 $qb->expr()->in('id', $qb->quoteArrayBasedValueListToStringList($ids))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function findOlderThan(\DateTimeInterface $dateTime): array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tx_ximatwitterclient_domain_model_tweet');
+        $qb->getRestrictions()->removeAll();
+        return $qb->select('uid')
+            ->from('tx_ximatwitterclient_domain_model_tweet')
+            ->where(
+                $qb->expr()->lt('date', $qb->createNamedParameter($dateTime->getTimestamp(), Connection::PARAM_INT))
             )
             ->executeQuery()
             ->fetchAllAssociative();

--- a/Classes/Domain/Repository/TweetRepository.php
+++ b/Classes/Domain/Repository/TweetRepository.php
@@ -2,7 +2,7 @@
 
 namespace Xima\XimaTwitterClient\Domain\Repository;
 
-use Doctrine\DBAL\Connection;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -15,6 +15,7 @@ class TweetRepository extends Repository
     {
         parent::__construct();
     }
+
     /**
      * @param string[] $ids
      * @return list<array<string, mixed>>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,6 +14,12 @@ services:
         command: 'twitter:fetchTweets'
         schedulable: true
 
+  Xima\XimaTwitterClient\Command\CleanupTweetsCommand:
+    tags:
+      - name: 'console.command'
+        command: 'twitter:cleanupTweets'
+        schedulable: true
+
   Xima\XimaTwitterClient\FetchType\LatestTweets:
     public: true
 


### PR DESCRIPTION
closes #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schedulable console command `twitter:cleanupTweets` to remove tweets older than a configurable retention period (default 180 days). Use `--lifetime` to set the retention and `--dry-run` to preview deletions without changing data. Command reports counts of removed tweets and associated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->